### PR TITLE
docs: add Hanzilla Jobs to search resources

### DIFF
--- a/docs/job_search.md
+++ b/docs/job_search.md
@@ -33,6 +33,7 @@ GitHub上有些库也会时不时更新新开发的岗位，一般是基于爬�
 
 - [SimplifyJobs/Summer2025-Internships](https://github.com/SimplifyJobs/Summer2025-Internships)
 - [speedyapply/2025-SWE-College-Jobs](https://github.com/speedyapply/2025-SWE-College-Jobs)
+- [Hanzilla Jobs](https://jobs.hanzilla.co/internships/): Canada-focused daily-updated student/recent-grad job board for internships, co-op, new grad, junior, and entry-level roles across tech, finance, engineering, business, and sciences.
 
 <p align="center">
 	<img src="assets/simplify_repo.png" >

--- a/docs/job_search.md
+++ b/docs/job_search.md
@@ -33,7 +33,7 @@ GitHub上有些库也会时不时更新新开发的岗位，一般是基于爬�
 
 - [SimplifyJobs/Summer2025-Internships](https://github.com/SimplifyJobs/Summer2025-Internships)
 - [speedyapply/2025-SWE-College-Jobs](https://github.com/speedyapply/2025-SWE-College-Jobs)
-- [Hanzilla Jobs](https://jobs.hanzilla.co/internships/): Canada-focused daily-updated student/recent-grad job board for internships, co-op, new grad, junior, and entry-level roles across tech, finance, engineering, business, and sciences.
+- [Hanzilla Jobs](https://jobs.hanzilla.co/internships/)：面向加拿大大学生和应届毕业生的免费岗位板，每日更新 internship、co-op、new grad、junior 和 entry-level 岗位，覆盖科技、金融、工程、商科、理科等方向。
 
 <p align="center">
 	<img src="assets/simplify_repo.png" >


### PR DESCRIPTION
## Summary
- Adds Hanzilla Jobs to the job-search resources list in `docs/job_search.md`.
- Uses the internships deep link because the guide focuses on internship/new-grad search channels.

## Context
This follows your suggestion on SamZhang02/Canadian-Tech-Internships-Winter-2025#2 to add the resource here as well.

Hanzilla Jobs is a free daily-updated Canadian student/recent-grad job board covering internships, co-op, new grad, junior, and entry-level roles across tech, finance, engineering, business, and sciences.

## Test plan
- `git diff --check`
